### PR TITLE
Docs: Add Dijkstra Blog documentation pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,6 @@
       "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.35.1.tgz",
       "integrity": "sha512-/hshlAayMd3B+E+h8wY6JWT1lNmX/K1+ugiZPirW5XFo5QUcNMk/Bsa4oHgg+TFoU6kbxPtijo0VppATfD9XuA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/markdown-remark": "^6.3.1",
         "@astrojs/mdx": "^4.2.3",
@@ -2051,7 +2050,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2212,7 +2210,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.12.0.tgz",
       "integrity": "sha512-Oov5JsMFHuUmuO+Nx6plfv3nQNK1Xl/8CgLvR8lBhZTjYnraxhuPX5COVAzbom+YLgwaDfK7KBd8zOEopRf9mg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.6.1",
@@ -5904,7 +5901,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6382,7 +6378,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
       "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6659,8 +6654,7 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.2",
@@ -7149,7 +7143,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7373,7 +7366,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/content/docs/dijkstra-frontends/dijkstra-blog/introduction.md
+++ b/src/content/docs/dijkstra-frontends/dijkstra-blog/introduction.md
@@ -1,6 +1,72 @@
 ---
-title: "Introduction to Dijkstra's Blog"
-description: "Learn the basics of Dijkstra's Blog"
+title: Dijkstra Blog Introduction
+description: Overview of the Dijkstra Blog platform, its purpose, and how it fits into the Dijkstra ecosystem.
 ---
 
-# Introduction to Dijkstra's Blog
+## What is the Dijkstra Blog?
+
+The **Dijkstra Blog** is the official public blogging platform within the Dijkstra ecosystem. It is designed as a space where students and developers can share technical knowledge, document their learning, and showcase the work they have done.
+
+Unlike the main Dijkstra dashboard — which focuses on tracking growth, tasks, and structured development — the blog is built for **public knowledge sharing**.
+
+---
+
+## Why the Blog Exists
+
+The Dijkstra Blog was created to:
+
+- Encourage students to document their learning journey  
+- Provide a platform for technical writing and knowledge sharing  
+- Turn individual effort into visible **proof of work**  
+- Help contributors explain concepts clearly and build communication skills  
+- Make learning resources accessible to other students  
+
+Writing is treated as part of learning. Explaining a concept strengthens understanding and helps others at the same time.
+
+---
+
+## How It Fits Into Dijkstra
+
+The Dijkstra ecosystem consists of different parts, each serving a role:
+
+| Component | Focus |
+|----------|------|
+| **Main Dashboard** | Skill tracking, tasks, and structured growth |
+| **Projects & Contributions** | Real-world development experience |
+| **Dijkstra Blog** | Public technical writing and knowledge sharing |
+
+The blog connects personal learning to the wider community by making knowledge public.
+
+---
+
+## What Kind of Content Is Published
+
+The blog supports structured technical articles such as:
+
+- Data Structures & Algorithms explanations  
+- LeetCode-style problem breakdowns  
+- Computer Science fundamentals (OS, DBMS, Networks, etc.)  
+- Project documentation and engineering write-ups  
+- Learning notes and deep dives  
+- Personal technical journeys  
+
+Each article reflects the understanding and voice of the contributor.
+
+---
+
+## Who the Blog Is For
+
+The Dijkstra Blog is intended for:
+
+- Students learning computer science  
+- Developers improving problem-solving skills  
+- Contributors documenting projects  
+- Anyone who wants to share technical knowledge clearly  
+
+Advanced expertise is not required — clarity and structured explanation matter more than complexity.
+
+---
+
+The core idea behind the Dijkstra Blog is simple:
+
+**Learning becomes more powerful when it is shared.**

--- a/src/content/docs/dijkstra-frontends/dijkstra-blog/recreation/how-to-recreate-blog.md
+++ b/src/content/docs/dijkstra-frontends/dijkstra-blog/recreation/how-to-recreate-blog.md
@@ -1,4 +1,207 @@
 ---
-title: Recreate Dijkstra Blog
-description: Step-by-step guide to recreate or restore the Dijkstra Blog environment.
+title: How to Recreate Blog
+description: Step-by-step guide to rebuilding the Dijkstra Blog platform from scratch using Astro.
 ---
+
+## Overview
+
+This guide explains how to recreate the Dijkstra Blog platform from the ground up.  
+The blog is built using **Astro**, focusing on performance, readability, and a content-first structure.
+
+This process is useful if you want to:
+
+- Set up a new instance of the blog
+- Understand the project architecture
+- Contribute at a deeper technical level
+
+---
+
+## 1. Prerequisites
+
+Make sure you have the following installed:
+
+- **Node.js** (v18 or later recommended)
+- **npm** or **pnpm**
+- **Git**
+
+Check versions:
+
+```bash
+node -v
+npm -v
+git --version
+```
+
+---
+
+## 2. Create a New Astro Project
+
+Initialize a fresh Astro project:
+
+```bash
+npm create astro@latest
+```
+
+Select:
+
+- **Template** → Minimal or Blog template  
+- **TypeScript** → Yes (recommended)  
+- **Install dependencies** → Yes  
+
+Navigate into the project:
+
+```bash
+cd your-project-name
+```
+
+---
+
+## 3. Install Required Integrations
+
+Install core tools used in the Dijkstra Blog:
+
+```bash
+npm install @astrojs/mdx @astrojs/sitemap @astrojs/tailwind
+```
+
+Then add them to `astro.config.mjs`:
+
+```js
+import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
+import sitemap from '@astrojs/sitemap';
+import tailwind from '@astrojs/tailwind';
+
+export default defineConfig({
+  integrations: [mdx(), sitemap(), tailwind()]
+});
+```
+
+---
+
+## 4. Project Structure
+
+Recreate the folder structure:
+
+```
+src/
+ ├── components/
+ ├── layouts/
+ ├── pages/
+ ├── content/
+ │    └── blog/
+ └── styles/
+```
+
+- **components/** → Reusable UI elements  
+- **layouts/** → Blog post layout templates  
+- **pages/** → Static pages  
+- **content/blog/** → Markdown blog posts  
+
+---
+
+## 5. Configure Content Collections
+
+Inside `src/content/config.ts`:
+
+```ts
+import { defineCollection, z } from 'astro:content';
+
+const blog = defineCollection({
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.date().optional(),
+  }),
+});
+
+export const collections = { blog };
+```
+
+This ensures all blog posts follow the same structure.
+
+---
+
+## 6. Create a Blog Layout
+
+Inside `src/layouts/BlogLayout.astro`:
+
+```astro
+---
+const { title, description } = Astro.props;
+---
+
+<html>
+  <head>
+    <title>{title}</title>
+    <meta name="description" content={description} />
+  </head>
+  <body>
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>
+```
+
+---
+
+## 7. Add a Sample Blog Post
+
+Create `src/content/blog/first-post.md`:
+
+```md
+---
+title: My First Blog
+description: Example post
+pubDate: 2024-01-01
+---
+
+Welcome to the Dijkstra Blog platform built with Astro.
+```
+
+---
+
+## 8. Run the Project
+
+```bash
+npm run dev
+```
+
+Open the local server URL to verify the blog loads correctly.
+
+---
+
+## 9. Build for Production
+
+```bash
+npm run build
+```
+
+This generates the optimized static site.
+
+---
+
+## 10. Deploy
+
+You can deploy using:
+
+- Vercel  
+- Netlify  
+- GitHub Pages  
+- Any static hosting provider  
+
+Upload the `dist/` folder generated after build.
+
+---
+
+## Key Takeaway
+
+The Dijkstra Blog architecture is designed to be:
+
+- Fast  
+- Simple  
+- Markdown-driven  
+- Easy to scale  
+
+Recreating it requires only Astro, structured content, and clean component design.

--- a/src/content/docs/dijkstra-frontends/dijkstra-blog/setup-and-deployment/how-deployment-works.md
+++ b/src/content/docs/dijkstra-frontends/dijkstra-blog/setup-and-deployment/how-deployment-works.md
@@ -1,4 +1,87 @@
 ---
-title: Blog Deployment Process
-description: Understanding how the Dijkstra Blog is deployed and managed.
+title: How Deployment Works
+description: Overview of how the Dijkstra Blog is built, deployed, and made available to users.
 ---
+
+## Overview
+
+The Dijkstra Blog is deployed as a **static, content-driven website**. The deployment process is designed to be simple, reliable, and optimized for fast content delivery.
+
+The system focuses on:
+- Fast load times
+- Easy content updates
+- Minimal backend complexity
+- Stable public access
+
+---
+
+## Deployment Architecture
+
+The deployment flow follows a straightforward pipeline:
+
+**Content → Build → Static Output → Hosting**
+
+1. **Content Creation**  
+   Blog posts are written in Markdown and stored within the repository.
+
+2. **Build Process**  
+   When changes are pushed to the repository, the project is built using the Astro framework.  
+   During the build:
+   - Markdown content is converted into static HTML
+   - Pages are structured and optimized
+   - Assets are bundled and prepared for delivery
+
+3. **Static Output Generation**  
+   The build produces a static site, meaning:
+   - No server-side rendering is required at runtime
+   - Pages are pre-generated
+   - Performance is consistent and predictable
+
+4. **Hosting**  
+   The generated site is deployed to the hosting platform and made available at:
+
+   👉 **https://blog.dijkstra.org.in**
+
+---
+
+## Why Static Deployment?
+
+The Dijkstra Blog uses static deployment because:
+
+- It improves **performance** (no runtime server processing)
+- It increases **security** (no backend logic exposed)
+- It simplifies **infrastructure management**
+- It makes scaling easier
+- It reduces the chances of runtime failures
+
+Since the blog mainly delivers content, a static approach is efficient and reliable.
+
+---
+
+## How Updates Reach the Live Site
+
+Whenever a contributor adds or updates a blog:
+
+1. Changes are pushed to the repository  
+2. The deployment pipeline triggers automatically  
+3. The site is rebuilt  
+4. The updated static version replaces the old one  
+5. Changes become visible on the live blog
+
+This ensures the blog stays up to date without manual server management.
+
+---
+
+## Responsibilities During Deployment
+
+| Role | Responsibility |
+|------|----------------|
+| **Contributors** | Add and update blog content |
+| **Maintainers** | Review changes and manage repository structure |
+| **Deployment System** | Build and publish the updated site automatically |
+
+---
+
+## Key Takeaway
+
+Deployment for the Dijkstra Blog is designed to stay in the background. Contributors focus on writing and improving content, while the build and hosting process ensures that the blog remains fast, secure, and consistently available.

--- a/src/content/docs/dijkstra-frontends/dijkstra-blog/setup-and-deployment/how-to-run-locally.md
+++ b/src/content/docs/dijkstra-frontends/dijkstra-blog/setup-and-deployment/how-to-run-locally.md
@@ -1,4 +1,126 @@
 ---
-title: Run Dijkstra Blog Locally
-description: Instructions for setting up and running the Dijkstra Blog locally.
+title: How to Run Locally
+description: Steps to set up and run the Dijkstra Blog on your local machine for development and testing.
 ---
+
+## Overview
+
+Running the Dijkstra Blog locally allows contributors to:
+
+- Preview blog posts before publishing  
+- Test formatting and layout  
+- Make structural or design improvements  
+- Ensure content renders correctly  
+
+The blog is built using **Astro**, so the local setup is lightweight and fast.
+
+---
+
+## Prerequisites
+
+Make sure you have the following installed:
+
+- **Node.js** (v18 or later recommended)
+- **npm** (comes with Node.js)  
+  or  
+- **pnpm / yarn** (optional alternative package managers)
+
+---
+
+## Step 1 — Clone the Repository
+
+```bash
+git clone https://github.com/Dijkstra-Edu/Blog.git
+cd Blog
+```
+
+---
+
+## Step 2 — Install Dependencies
+
+Install all required project packages:
+
+```bash
+npm install
+```
+
+If using pnpm:
+
+```bash
+pnpm install
+```
+
+---
+
+## Step 3 — Start the Development Server
+
+Run the local development server:
+
+```bash
+npm run dev
+```
+
+Astro will start a local server, typically at:
+
+👉 `http://localhost:4321`
+
+Open this URL in your browser to view the blog.
+
+---
+
+## Step 4 — Make Changes
+
+You can now:
+
+- Add or edit Markdown blog files  
+- Update layouts or components  
+- Modify styles  
+
+The development server supports **hot reload**, meaning changes appear instantly without restarting the server.
+
+---
+
+## Step 5 — Build Locally (Optional)
+
+To verify the production build:
+
+```bash
+npm run build
+```
+
+To preview the production version locally:
+
+```bash
+npm run preview
+```
+
+---
+
+## Common Issues
+
+**Port already in use**  
+If port 4321 is busy, Astro will suggest another available port.
+
+**Dependencies not installing**  
+Try deleting `node_modules` and `package-lock.json`, then run:
+
+```bash
+npm install
+```
+
+---
+
+## When to Run Locally
+
+You should run the project locally when:
+
+- Writing or editing blog posts  
+- Working on layout or UI changes  
+- Fixing formatting issues  
+- Testing before opening a Pull Request  
+
+---
+
+## Key Takeaway
+
+Local setup ensures contributors can safely test their work before it goes live. It keeps the publishing process smooth while maintaining quality and consistency across the blog.

--- a/src/content/docs/dijkstra-frontends/dijkstra-blog/setup-and-deployment/how-to-test.md
+++ b/src/content/docs/dijkstra-frontends/dijkstra-blog/setup-and-deployment/how-to-test.md
@@ -1,4 +1,130 @@
 ---
-title: Testing Dijkstra Blog
-description: Guide to testing and verifying Dijkstra Blog functionality.
+title: How to Test
+description: Guidelines for testing blog content, formatting, and site behavior before publishing.
 ---
+
+## Overview
+
+Testing ensures that blog posts and site changes are accurate, readable, and function correctly before going live.  
+Even though the Dijkstra Blog focuses mainly on content, quality checks are important to maintain a professional and consistent platform.
+
+---
+
+## What Should Be Tested
+
+Contributors should verify:
+
+- Content formatting  
+- Markdown rendering  
+- Links and navigation  
+- Images and media  
+- Layout consistency  
+- Build success  
+
+---
+
+## 1. Content & Formatting Check
+
+Before publishing a blog post:
+
+- Ensure headings follow a proper hierarchy (`#`, `##`, `###`)
+- Check spacing between paragraphs and sections
+- Verify code blocks render correctly
+- Confirm lists and bullet points display properly
+- Avoid overly long paragraphs for readability
+
+---
+
+## 2. Markdown Rendering
+
+Run the project locally:
+
+```bash
+npm run dev
+```
+
+Then review the blog page to ensure:
+
+- Markdown converts correctly to styled content
+- Tables, quotes, and code blocks are displayed properly
+- Special characters are not broken
+
+---
+
+## 3. Link Testing
+
+Check that:
+
+- Internal links navigate to the correct pages
+- External links open correctly
+- No broken or outdated URLs exist
+
+Broken links reduce trust and affect usability.
+
+---
+
+## 4. Image & Media Check
+
+Ensure:
+
+- Images load correctly
+- Image paths are correct
+- Files are optimized (not unnecessarily large)
+- Alt text is provided for accessibility
+
+---
+
+## 5. Layout & Responsiveness
+
+Resize your browser or use dev tools to confirm:
+
+- Content looks good on desktop
+- Content remains readable on mobile screens
+- No layout breaks occur with long titles or code blocks
+
+---
+
+## 6. Build Test (Very Important)
+
+Before submitting changes, verify that the project builds successfully:
+
+```bash
+npm run build
+```
+
+If the build fails, there may be:
+
+- Syntax errors in Markdown
+- Missing files
+- Broken imports
+
+Fix these before pushing changes.
+
+---
+
+## 7. Preview Production Version
+
+To preview the final version:
+
+```bash
+npm run preview
+```
+
+This simulates how the blog will look after deployment.
+
+---
+
+## Common Mistakes to Avoid
+
+- Missing frontmatter in blog files
+- Incorrect file paths for images
+- Unclosed Markdown code blocks
+- Using unsupported HTML tags
+- Large unoptimized images slowing down the page
+
+---
+
+## Key Takeaway
+
+Testing is not just for developers — it ensures readers have a smooth and professional experience.  
+A few minutes of testing prevents broken posts and keeps the Dijkstra Blog reliable and high quality.


### PR DESCRIPTION
This PR adds documentation for the Dijkstra Blog section in the Docs site.

Pages added:
- Introduction
- How Deployment Works
- How to Run Locally
- How to Test
- How to Recreate Blog
